### PR TITLE
Corrected usage of shebang

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-#!/usr/bin/env just --justfile
+#!/usr/bin/env -S just --justfile
 
 default: build
 


### PR DESCRIPTION
Currently running `./justfile` produces the following error:

```bash
$ ./justfile 
/usr/bin/env: ‘just --justfile’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```

The newer versions of `/usr/bin/env` indicate that you should use -S to split arguments when passing them in shebang lines.
Added de required `-S` which fixes the problem.

```bash
 $ ./justfile
CGO_ENABLED=0 go build -trimpath -o ./bin/run-boinc ./cmd/run-boinc
```
